### PR TITLE
Bump dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,9 +17,9 @@
     "purescript-console": "^0.1.0"
   },
   "dependencies": {
-    "purescript-maps": "^0.5.0",
-    "purescript-node-streams": "^0.1.1",
-    "purescript-options": "~0.5.1",
-    "purescript-unsafe-coerce": "^0.1.0"
+    "purescript-maps": "^0.5.4",
+    "purescript-options": "^0.5.1",
+    "purescript-unsafe-coerce": "^0.1.0",
+    "purescript-node-streams": "^0.3.0"
   }
 }

--- a/src/Node/HTTP.purs
+++ b/src/Node/HTTP.purs
@@ -44,7 +44,7 @@ requestURL :: Request -> String
 requestURL = _.url <<< unsafeCoerce
 
 -- | Coerce the request object into a readable stream.
-requestAsStream :: forall eff a. Request -> Readable () (http :: HTTP | eff) a
+requestAsStream :: forall eff. Request -> Readable () (http :: HTTP | eff)
 requestAsStream = unsafeCoerce
 
 -- | Set a header with a single value.
@@ -60,5 +60,5 @@ foreign import setStatusCode :: forall eff. Response -> Int -> Eff (http :: HTTP
 foreign import setStatusMessage :: forall eff. Response -> String -> Eff (http :: HTTP | eff) Unit
 
 -- | Coerce the response object into a writable stream.
-responseAsStream :: forall eff a. Response -> Writable () (http :: HTTP | eff) a
+responseAsStream :: forall eff. Response -> Writable () (http :: HTTP | eff)
 responseAsStream = unsafeCoerce

--- a/src/Node/HTTP/Client.purs
+++ b/src/Node/HTTP/Client.purs
@@ -90,11 +90,11 @@ requestFromURI :: forall eff. String -> (Response -> Eff (http :: HTTP | eff) Un
 requestFromURI = requestImpl <<< toForeign
 
 -- | Create a writable stream from a request object.
-requestAsStream :: forall eff r a. Request -> Writable r (http :: HTTP | eff) a
+requestAsStream :: forall eff r. Request -> Writable r (http :: HTTP | eff)
 requestAsStream = unsafeCoerce
 
 -- | Create a readable stream from a response object.
-responseAsStream :: forall eff w a. Response -> Readable w (http :: HTTP | eff) a
+responseAsStream :: forall eff w. Response -> Readable w (http :: HTTP | eff)
 responseAsStream = unsafeCoerce
 
 -- | Set the socket timeout for a `Request`

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -12,7 +12,7 @@ import qualified Node.HTTP.Client as Client
 import Node.Stream
 import Node.Encoding
 
-foreign import stdout :: forall eff r a. Writable r eff a
+foreign import stdout :: forall eff r. Writable r eff
 
 main = do
   server <- createServer respond


### PR DESCRIPTION
Most other stuff is on `~0.3.0` of `node-streams`, so this commit allows `node-http` to be used with that other stuff. :)
