### PR TITLE
update for purescript 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,13 +12,13 @@
     "url": "git://github.com/purescript-node/purescript-node-http.git"
   },
   "devDependencies": {
-    "purescript-console": "^2.0.0"
+    "purescript-console": "^3.0.0"
   },
   "dependencies": {
-    "purescript-maps": "^2.0.0",
-    "purescript-node-streams": "^2.0.0",
-    "purescript-node-url": "^2.0.0",
-    "purescript-options": "^2.0.0",
-    "purescript-unsafe-coerce": "^2.0.0"
+    "purescript-maps": "^3.0.0",
+    "purescript-node-streams": "^3.0.0",
+    "purescript-node-url": "^3.0.0",
+    "purescript-options": "^3.0.0",
+    "purescript-unsafe-coerce": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "jshint src && jscs src && pulp build --censor-lib --strict",
+    "build": "jshint src && jscs src && pulp build -- --censor-lib --strict",
     "test": "pulp build -I test"
   },
   "devDependencies": {
     "jscs": "^3.0.7",
     "jshint": "^2.9.4",
-    "pulp": "^9.0.1",
-    "purescript-psa": "^0.3.9",
-    "purescript": "^0.10.1",
-    "rimraf": "^2.5.4"
+    "pulp": "^11.0.0",
+    "purescript": "^0.11.1",
+    "purescript-psa": "^0.5.0",
+    "rimraf": "^2.6.1"
   }
 }

--- a/src/Node/HTTP.purs
+++ b/src/Node/HTTP.purs
@@ -26,7 +26,7 @@ module Node.HTTP
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
+import Control.Monad.Eff (Eff, kind Effect)
 
 import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toNullable)
@@ -37,16 +37,16 @@ import Node.Stream (Writable, Readable)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | The type of a HTTP server object
-foreign import data Server :: *
+foreign import data Server :: Type
 
 -- | A HTTP request object
-foreign import data Request :: *
+foreign import data Request :: Type
 
 -- | A HTTP response object
-foreign import data Response :: *
+foreign import data Response :: Type
 
 -- | The effect associated with using the HTTP module.
-foreign import data HTTP :: !
+foreign import data HTTP :: Effect
 
 -- | Create a HTTP server, given a function to be executed when a request is received.
 foreign import createServer :: forall eff. (Request -> Response -> Eff (http :: HTTP | eff) Unit) -> Eff (http :: HTTP | eff) Server

--- a/src/Node/HTTP/Client.purs
+++ b/src/Node/HTTP/Client.purs
@@ -46,10 +46,10 @@ import Node.URL as URL
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | A HTTP request object
-foreign import data Request :: *
+foreign import data Request :: Type
 
 -- | A HTTP response object
-foreign import data Response :: *
+foreign import data Response :: Type
 
 -- | A HTTP request object
 newtype RequestHeaders = RequestHeaders (StrMap String)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -44,7 +44,7 @@ testBasic = do
               , "</form>"
               ]
         setHeader res "Content-Type" "text/html"
-        writeString outputStream UTF8 html (pure unit)
+        _ <- writeString outputStream UTF8 html (pure unit)
         end outputStream (pure unit)
       "POST" -> void $ pipe inputStream outputStream
       _ -> unsafeCrashWith "Unexpected HTTP method"


### PR DESCRIPTION
Assumes releases for `purescript-node-streams^3.0.0`, `purescript-node-url^3.0.0`, `purescript-options^3.0.0`. Until then, this PR can wait here.

https://github.com/purescript-node/purescript-node-streams/pull/13
https://github.com/purescript-node/purescript-node-url/pull/5
https://github.com/purescript-contrib/purescript-options/pull/19