### PR TITLE
Move important functions first

### DIFF
--- a/src/Node/HTTP/Secure.purs
+++ b/src/Node/HTTP/Secure.purs
@@ -88,9 +88,6 @@ import Node.Buffer (Buffer)
 import Node.HTTP (Request, Response, Server, HTTP)
 import Unsafe.Coerce (unsafeCoerce)
 
--- | The type of HTTPS server options
-data SSLOptions
-
 -- | Create an HTTPS server, given the SSL options and a function to be executed
 -- | when a request is received.
 foreign import createServerImpl ::
@@ -106,6 +103,9 @@ createServer :: forall eff.
                 (Request -> Response -> Eff (http :: HTTP | eff) Unit) ->
                 Eff (http :: HTTP | eff) Server
 createServer = createServerImpl <<< options
+
+-- | The type of HTTPS server options
+data SSLOptions
 
 -- | See the [node docs](https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener)
 handshakeTimeout :: Option SSLOptions Int

--- a/src/Node/HTTP/Secure.purs
+++ b/src/Node/HTTP/Secure.purs
@@ -91,6 +91,22 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | The type of HTTPS server options
 data SSLOptions
 
+-- | Create an HTTPS server, given the SSL options and a function to be executed
+-- | when a request is received.
+foreign import createServerImpl ::
+  forall eff.
+  Foreign ->
+  (Request -> Response -> Eff (http :: HTTP | eff) Unit) ->
+  Eff (http :: HTTP | eff) Server
+
+-- | Create an HTTPS server, given the SSL options and a function to be executed
+-- | when a request is received.
+createServer :: forall eff.
+                Options SSLOptions ->
+                (Request -> Response -> Eff (http :: HTTP | eff) Unit) ->
+                Eff (http :: HTTP | eff) Server
+createServer = createServerImpl <<< options
+
 -- | See the [node docs](https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener)
 handshakeTimeout :: Option SSLOptions Int
 handshakeTimeout = opt "handshakeTimeout"
@@ -264,19 +280,3 @@ secureOptions = opt "secureOptions"
 -- | See the [node docs](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options)
 sessionIdContext :: Option SSLOptions String
 sessionIdContext = opt "sessionIdContext"
-
--- | Create an HTTPS server, given the SSL options and a function to be executed
--- | when a request is received.
-foreign import createServerImpl ::
-  forall eff.
-  Foreign ->
-  (Request -> Response -> Eff (http :: HTTP | eff) Unit) ->
-  Eff (http :: HTTP | eff) Server
-
--- | Create an HTTPS server, given the SSL options and a function to be executed
--- | when a request is received.
-createServer :: forall eff.
-                Options SSLOptions ->
-                (Request -> Response -> Eff (http :: HTTP | eff) Unit) ->
-                Eff (http :: HTTP | eff) Server
-createServer = createServerImpl <<< options


### PR DESCRIPTION
I just realized that having the most important function (`createServer`) last makes the docs crazy hard to read.  This PR just moves the `createServer` function to the top of the file, so it's the first function in the docs for `Node.HTTP.Secure`.