### PR TITLE
bugfix/20 - added some metadata to make yarn happy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "name": "purescript-node-http",
+  "license": "MIT",
+  "version": "4.2.0",
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",


### PR DESCRIPTION
Hi,

bower is deprecated in favor of yarn. As it is, yarn croaks because some properties - namely, name :) - are missing, but simply adding them makes it happy. I took the liberty of also copying license and version from bower.json... 