### PR TITLE
Add support for `update` events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.14.0-rc3"
+          purescript: "0.14.0-rc5"
 
       - uses: actions/setup-node@v1
         with:

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "purescript-foreign-object": "master",
     "purescript-maybe": "master",
     "purescript-node-buffer": "master",
+    "purescript-node-net": "master",
     "purescript-node-streams": "master",
     "purescript-node-url": "master",
     "purescript-nullable": "main",

--- a/src/Node/HTTP.js
+++ b/src/Node/HTTP.js
@@ -46,6 +46,16 @@ exports.listenSocket = function (server) {
   };
 };
 
+exports.onUpgrade = function (server) {
+  return function (cb) {
+    return function () {
+      server.on("upgrade", function (req, socket, buffer) {
+        return cb(req)(socket)(buffer)();
+      });
+    };
+  };
+};
+
 exports.setHeader = function (res) {
   return function (key) {
     return function (value) {

--- a/src/Node/HTTP.purs
+++ b/src/Node/HTTP.purs
@@ -10,6 +10,7 @@ module Node.HTTP
   , close
   , ListenOptions
   , listenSocket
+  , onUpgrade
 
   , httpVersion
   , requestHeaders
@@ -30,6 +31,8 @@ import Data.Maybe (Maybe)
 import Data.Nullable (Nullable, toNullable)
 import Effect (Effect)
 import Foreign.Object (Object)
+import Node.Buffer (Buffer)
+import Node.Net.Socket (Socket)
 import Node.Stream (Writable, Readable)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -66,6 +69,9 @@ type ListenOptions =
 
 -- | Listen on a unix socket. The specified callback will be run when setup is complete.
 foreign import listenSocket :: Server -> String -> Effect Unit -> Effect Unit
+
+-- | Listen to `upgrade` events on the server
+foreign import onUpgrade :: Server -> (Request -> Socket -> Buffer -> Effect Unit) -> Effect Unit
 
 -- | Get the request HTTP version
 httpVersion :: Request -> String


### PR DESCRIPTION
As discussed on #32, this allows users to listen and respond to HTTP upgrades.