### PR TITLE
Implement onConnect

### DIFF
--- a/src/Node/HTTP.js
+++ b/src/Node/HTTP.js
@@ -46,6 +46,16 @@ exports.listenSocket = function (server) {
   };
 };
 
+exports.onConnect = function (server) {
+  return function (cb) {
+    return function () {
+      server.on("connect", function (req, socket, buffer) {
+        return cb(req)(socket)(buffer)();
+      });
+    };
+  };
+};
+
 exports.onUpgrade = function (server) {
   return function (cb) {
     return function () {

--- a/src/Node/HTTP.purs
+++ b/src/Node/HTTP.purs
@@ -10,6 +10,7 @@ module Node.HTTP
   , close
   , ListenOptions
   , listenSocket
+  , onConnect
   , onUpgrade
 
   , httpVersion
@@ -69,6 +70,9 @@ type ListenOptions =
 
 -- | Listen on a unix socket. The specified callback will be run when setup is complete.
 foreign import listenSocket :: Server -> String -> Effect Unit -> Effect Unit
+
+-- | Listen to `connect` events on the server
+foreign import onConnect :: Server -> (Request -> Socket -> Buffer -> Effect Unit) -> Effect Unit
 
 -- | Listen to `upgrade` events on the server
 foreign import onUpgrade :: Server -> (Request -> Socket -> Buffer -> Effect Unit) -> Effect Unit


### PR DESCRIPTION
**Description of the change**

This PR allows to use the "connect" event  which can be useful to implement an http proxy server. Following the example from the nodeJS documentation https://nodejs.org/api/http.html#http_event_connect

```
respond :: Request -> Response -> Effect Unit
respond req res = do
  setStatusCode res 200
  setHeader res "Content-Type" "text/plain"

main :: Effect Unit
main = do
  proxy <- createServer respond
  listen proxy { hostname: "localhost", port: 3030, backlog: Nothing} $ void do
    log "Listening on port 3030"
    onConnect proxy $ \req clientSocket head -> void do
      log (requestMethod req <> " " <> requestURL req)
      logShow $ requestHeaders req
      let url = parse $ "http://" <> requestURL req
      logShow url 
      case (toMaybe url.port), (toMaybe url.hostname) of
        Just stringPort, Just host -> case fromString stringPort of
          Just port -> do
            serverSocket <- Socket.createConnectionTCP port host do
                infoShow $ "CONNECT " <> host

            Socket.onConnect serverSocket do
              -- infoShow { _message: "Socket connected" }
              void $ Socket.writeString clientSocket 
                ("HTTP/1.1 200 Connection Established\r\n" <>
                "Proxy-agent: Node.js-Proxy\r\n" <>
                "\r\n") UTF8 $ pure unit
              void $ Socket.write serverSocket head $ pure unit
              void $ Socket.onData serverSocket $ case _ of
                Left buffer -> void $ Socket.write clientSocket buffer $ pure unit
                Right string -> void $ Socket.writeString clientSocket string UTF8 $ pure unit
              void $ Socket.onData clientSocket $ case _ of
                Left buffer -> void $ Socket.write serverSocket buffer $ pure unit
                Right string -> void $ Socket.writeString serverSocket string UTF8 $ pure unit
            Socket.onError serverSocket \err -> do
              infoShow { _message: "Server had an error", err }
            Socket.onError clientSocket \err -> do
              infoShow { _message: "Client had an error", err }
          _ -> log "port is not a string"
        _,_ -> log "port or hosts error"
```

No tests yet!

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
