### PR TITLE
Disable tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Run tests
         run: |
           bower install
-          npm run-script test --if-present
+          # npm run-script test --if-present


### PR DESCRIPTION
**Description of the change**

The tests do not currently terminate, which we'll need to fix at a later point by just making them terminate and then re-enabling them. At the moment, though, this simply disables the tests in CI so that we don't burn CI minutes.

Related: https://github.com/purescript-node/purescript-node-http/issues/35

---

**Checklist:**

- ~Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")~
- ~Linked any existing issues or proposals that this pull request should close~
- ~Updated or added relevant documentation~
- ~Added a test for the contribution (if applicable)~
