### PR TITLE
Fix upgrade test; correct/add APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes:
 - Update node libraries to latest releases (#48 by @JordanMartinez)
-- Reimplement `http`/`https` bindings (#49 by @JordanMartinez)
+- Reimplement `http`/`https` bindings (#49, #50 by @JordanMartinez)
 
 New features:
 
 Bugfixes:
 
 Other improvements:
+- Fix flaky `upgrade` test (#50 by @JordanMartinez)
 
 ## [v8.0.0](https://github.com/purescript-node/purescript-node-http/releases/tag/v8.0.0) - 2022-04-29
 

--- a/src/Node/HTTP/ClientRequest.purs
+++ b/src/Node/HTTP/ClientRequest.purs
@@ -1,5 +1,6 @@
 module Node.HTTP.ClientRequest
   ( toOutgoingMessage
+  , closeH
   , connectH
   , continueH
   , finishH
@@ -34,6 +35,9 @@ import Unsafe.Coerce (unsafeCoerce)
 
 toOutgoingMessage :: ClientRequest -> OutgoingMessage
 toOutgoingMessage = unsafeCoerce
+
+closeH :: EventHandle0 ClientRequest
+closeH = EventHandle "close" identity
 
 connectH :: EventHandle3 ClientRequest (IncomingMessage IMClientRequest) (Socket TCP) Buffer
 connectH = EventHandle "connect" \cb -> mkEffectFn3 \a b c -> cb a b c

--- a/src/Node/HTTP/ClientRequest.purs
+++ b/src/Node/HTTP/ClientRequest.purs
@@ -29,13 +29,13 @@ import Node.Buffer (Buffer)
 import Node.EventEmitter (EventHandle(..))
 import Node.EventEmitter.UtilTypes (EventHandle0, EventHandle3, EventHandle1)
 import Node.HTTP.Types (ClientRequest, IMClientRequest, IncomingMessage, OutgoingMessage)
-import Node.Stream (Duplex)
+import Node.Net.Types (Socket, TCP)
 import Unsafe.Coerce (unsafeCoerce)
 
 toOutgoingMessage :: ClientRequest -> OutgoingMessage
 toOutgoingMessage = unsafeCoerce
 
-connectH :: EventHandle3 ClientRequest (IncomingMessage IMClientRequest) Duplex Buffer
+connectH :: EventHandle3 ClientRequest (IncomingMessage IMClientRequest) (Socket TCP) Buffer
 connectH = EventHandle "connect" \cb -> mkEffectFn3 \a b c -> cb a b c
 
 continueH :: EventHandle0 ClientRequest
@@ -59,13 +59,13 @@ informationH = EventHandle "information" mkEffectFn1
 responseH :: EventHandle1 ClientRequest (IncomingMessage IMClientRequest)
 responseH = EventHandle "response" mkEffectFn1
 
-socketH :: EventHandle1 ClientRequest Duplex
+socketH :: EventHandle1 ClientRequest (Socket TCP)
 socketH = EventHandle "socket" mkEffectFn1
 
 timeoutH :: EventHandle0 ClientRequest
 timeoutH = EventHandle "timeout" identity
 
-upgradeH :: EventHandle3 ClientRequest (IncomingMessage IMClientRequest) Duplex Buffer
+upgradeH :: EventHandle3 ClientRequest (IncomingMessage IMClientRequest) (Socket TCP) Buffer
 upgradeH = EventHandle "upgrade" \cb -> mkEffectFn3 \a b c -> cb a b c
 
 foreign import path :: ClientRequest -> String

--- a/src/Node/HTTP/IncomingMessage.purs
+++ b/src/Node/HTTP/IncomingMessage.purs
@@ -30,7 +30,8 @@ import Foreign.Object as Object
 import Node.EventEmitter (EventHandle(..))
 import Node.EventEmitter.UtilTypes (EventHandle0)
 import Node.HTTP.Types (IMClientRequest, IMServer, IncomingMessage)
-import Node.Stream (Readable, Duplex)
+import Node.Net.Types (Socket, TCP)
+import Node.Stream (Readable)
 import Unsafe.Coerce (unsafeCoerce)
 
 toReadable :: forall messageType. IncomingMessage messageType -> Readable ()
@@ -65,10 +66,10 @@ rawTrailers im = toMaybe $ rawTrailersImpl im
 
 foreign import rawTrailersImpl :: forall messageType. IncomingMessage messageType -> (Nullable (Array String))
 
-socket :: forall messageType. IncomingMessage messageType -> Effect (Maybe Duplex)
+socket :: forall messageType. IncomingMessage messageType -> Effect (Maybe (Socket TCP))
 socket im = map toMaybe $ runEffectFn1 socketImpl im
 
-foreign import socketImpl :: forall messageType. EffectFn1 (IncomingMessage messageType) (Nullable Duplex)
+foreign import socketImpl :: forall messageType. EffectFn1 (IncomingMessage messageType) (Nullable (Socket TCP))
 
 foreign import statusCode :: IncomingMessage IMClientRequest -> Int
 

--- a/src/Node/HTTP/OutgoingMessage.purs
+++ b/src/Node/HTTP/OutgoingMessage.purs
@@ -31,6 +31,7 @@ import Foreign.Object (Object)
 import Node.EventEmitter (EventHandle(..))
 import Node.EventEmitter.UtilTypes (EventHandle0)
 import Node.HTTP.Types (OutgoingMessage)
+import Node.Net.Types (Socket, TCP)
 import Node.Stream (Writable)
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -111,7 +112,7 @@ setTimeout msecs msg = runEffectFn2 setTimeoutImpl msecs msg
 
 foreign import setTimeoutImpl :: EffectFn2 (Milliseconds) (OutgoingMessage) (Unit)
 
-socket :: OutgoingMessage -> Effect (Maybe (Writable ()))
+socket :: OutgoingMessage -> Effect (Maybe (Socket TCP))
 socket msg = map toMaybe $ runEffectFn1 socketImpl msg
 
-foreign import socketImpl :: EffectFn1 (OutgoingMessage) (Nullable (Writable ()))
+foreign import socketImpl :: EffectFn1 (OutgoingMessage) (Nullable (Socket TCP))

--- a/src/Node/HTTP/Server.purs
+++ b/src/Node/HTTP/Server.purs
@@ -45,7 +45,7 @@ import Node.Buffer (Buffer)
 import Node.EventEmitter (EventHandle(..))
 import Node.EventEmitter.UtilTypes (EventHandle0, EventHandle2, EventHandle3, EventHandle1)
 import Node.HTTP.Types (Encrypted, HttpServer', IMServer, IncomingMessage, ServerResponse)
-import Node.Net.Types (Server, TCP)
+import Node.Net.Types (Server, Socket, TCP)
 import Node.Stream (Duplex)
 import Node.TLS.Types (TlsServer)
 import Unsafe.Coerce (unsafeCoerce)
@@ -76,7 +76,7 @@ clientErrorH = EventHandle "clientError" \cb -> mkEffectFn2 \a b -> cb a b
 closeH :: forall transmissionType. EventHandle0 (HttpServer' transmissionType)
 closeH = EventHandle "close" identity
 
-connectH :: forall transmissionType. EventHandle3 (HttpServer' transmissionType) (IncomingMessage IMServer) Duplex Buffer
+connectH :: forall transmissionType. EventHandle3 (HttpServer' transmissionType) (IncomingMessage IMServer) (Socket TCP) Buffer
 connectH = EventHandle "connect" \cb -> mkEffectFn3 \a b c -> cb a b c
 
 connectionH :: forall transmissionType. EventHandle1 (HttpServer' transmissionType) Duplex
@@ -88,7 +88,7 @@ dropRequestH = EventHandle "dropRequest" \cb -> mkEffectFn2 \a b -> cb a b
 requestH :: forall transmissionType. EventHandle2 (HttpServer' transmissionType) (IncomingMessage IMServer) ServerResponse
 requestH = EventHandle "request" \cb -> mkEffectFn2 \a b -> cb a b
 
-upgradeH :: forall transmissionType. EventHandle3 (HttpServer' transmissionType) (IncomingMessage IMServer) Duplex Buffer
+upgradeH :: forall transmissionType. EventHandle3 (HttpServer' transmissionType) (IncomingMessage IMServer) (Socket TCP) Buffer
 upgradeH = EventHandle "upgrade" \cb -> mkEffectFn3 \a b c -> cb a b c
 
 closeAllConnections :: forall transmissionType. (HttpServer' transmissionType) -> Effect Unit


### PR DESCRIPTION
**Description of the change**

Main focus of this PR was re-enabling the `upgrade` test I disabled temporarily in #48 by using `Aff`. 

Along the way, I realized that the `socket` types should be upgraded to `Socket TCP` because (at least AFAICT) we don't expose a way to provide a different class than `Socket`. I also noticed that the `ClientRequest` type was missing its `close` event handler.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
