### PR TITLE
Fix node-tls version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Bugfixes:
 
 Other improvements:
 
+## [v9.1.0](https://github.com/purescript-node/purescript-node-http/releases/tag/v9.1.0) - 2023-08-01
+
+Other improvements:
+- Update `node-tls` to `v0.3.1` to fix conflicting transitive dep on `node-buffer` (#52 by @JordanMartinez)
+
 ## [v9.0.0](https://github.com/purescript-node/purescript-node-http/releases/tag/v9.0.0) - 2023-08-01
 
 Breaking changes:

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "purescript-node-buffer": "^9.0.0",
     "purescript-node-net": "^5.1.0",
     "purescript-node-streams": "^9.0.0",
-    "purescript-node-tls": "https://github.com/JordanMartinez/purescript-node-tls.git#^0.3.0",
+    "purescript-node-tls": "https://github.com/purescript-node/purescript-node-tls.git#^0.3.1",
     "purescript-node-url": "^7.0.0",
     "purescript-nullable": "^6.0.0",
     "purescript-options": "^7.0.0",


### PR DESCRIPTION
**Description of the change**

`node-tls@0.3.0` didn't also update its `node-buffer` version (due to using package sets) to reference `9.0.0`, so it depended on `8.0.0` and introduced a conflict. This updates the version of `node-tls` to remove that conflict.

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
